### PR TITLE
Adds options to equiviliant exchange

### DIFF
--- a/data/equv/csv/Sosa Hayes-batting-equivilant-exchange.csv
+++ b/data/equv/csv/Sosa Hayes-batting-equivilant-exchange.csv
@@ -1,0 +1,11 @@
+player,combined_stars,team_name,rating
+Jaxon Buckley,17.99,Pies,6.59
+Rai Spliff,15.03,Steaks,5.14
+James Mora,18.02,Magic,5.1
+Conner Haley,17.17,Steaks,4.96
+Sam Scandal,17.77,Steaks,4.95
+-alik Destiny,18.51,Garages,4.84
+Blood Hamburger,15.87,Shoe Thieves,4.75
+Nerd Pacheco,15.87,Pies,4.55
+Hewitt Best,18.28,Breath Mints,4.52
+Jacob Winner,17.48,Fridays,4.42

--- a/data/equv/csv/york silk-pitching-equivilant-exchange.csv
+++ b/data/equv/csv/york silk-pitching-equivilant-exchange.csv
@@ -1,0 +1,11 @@
+player,combined_stars,team_name,rating
+Hiroto Wilcox,8.21,Tigers,4.06
+Bennett Bluesky,9.79,Spies,3.77
+Miguel James,10.4,Sunbeams,3.43
+Mags Banananana,10.1,Wild Wings,3.28
+Emmett Tabby,9.21,Spies,3.21
+Cudi Di Batterino,9.99,Lift,3.14
+Goobie Ballson,9.29,Firefighters,3.1
+Dunlap Figueroa,7.24,Tigers,3.1
+Silvia Rugrat,8.52,Wild Wings,3.08
+Fran Beans,10.44,Wild Wings,2.67

--- a/watcher/exts/playerstats.py
+++ b/watcher/exts/playerstats.py
@@ -186,9 +186,9 @@ class PlayerStats(commands.Cog):
     async def _equivalent_exchange(self, ctx, *, info):
         player_id = None
         info_split = info.split(",")
-        if len(info_split) <= 2:
-          return await ctx.send(f"Please include one of: baserunning, defense, pitching, hitting rating types.\n"
-                                  f"Command syntax: `!equivalent_exchange rating, player name, options`")
+        if len(info_split) < 2:
+          return await ctx.send(f"Please include one of: baserunning, defense, pitching, hitting rating types and a player you are intersted in\n"
+                                f"Command syntax: `!equivalent_exchange rating, player name, options`")
 
         raw_rating = info_split[0]
         player_name = string.capwords(info_split[1].strip())

--- a/watcher/exts/playerstats.py
+++ b/watcher/exts/playerstats.py
@@ -186,6 +186,16 @@ class PlayerStats(commands.Cog):
     async def _equivalent_exchange(self, ctx, *, info):
         player_id = None
         info_split = info.split(",")
+        if info_split[0].strip().lower() == "help":
+          return await ctx.send("""Command syntax: `!equivalent_exchange rating, player name, options`
+\t• `rating`: one of baserunning, defense, pitching, hitting as a sort order
+\t• `player name`: The player you are interested in
+\t• `options`: Include these terms seperated by a comma, order is not important
+\t\t ∙ output: `csv` or `inline` for how you want to output to be displayed (default: inline)
+\t\t ∙ limit: the number of results you want to show. Ignored for csv (default: 10)
+\t\t ∙ sort: `increasing` or `decreasing`, how the output should be sorted. (default: increasing)
+\t\t ∙ team: limits the search to just a particular team""")
+
         if len(info_split) < 2:
           return await ctx.send(f"Please include one of: baserunning, defense, pitching, hitting rating types and a player you are intersted in\n"
                                 f"Command syntax: `!equivalent_exchange rating, player name, options`")

--- a/watcher/exts/playerstats.py
+++ b/watcher/exts/playerstats.py
@@ -186,6 +186,10 @@ class PlayerStats(commands.Cog):
     async def _equivalent_exchange(self, ctx, *, info):
         player_id = None
         info_split = info.split(",")
+        if len(info_split) <= 2:
+          return await ctx.send(f"Please include one of: baserunning, defense, pitching, hitting rating types.\n"
+                                  f"Command syntax: `!equivalent_exchange rating, player name, options`")
+        
         raw_rating = info_split[0]
         player_name = string.capwords(info_split[1].strip())
         # allows parsing of various keys to the bot

--- a/watcher/exts/playerstats.py
+++ b/watcher/exts/playerstats.py
@@ -189,7 +189,7 @@ class PlayerStats(commands.Cog):
         if len(info_split) <= 2:
           return await ctx.send(f"Please include one of: baserunning, defense, pitching, hitting rating types.\n"
                                   f"Command syntax: `!equivalent_exchange rating, player name, options`")
-        
+
         raw_rating = info_split[0]
         player_name = string.capwords(info_split[1].strip())
         # allows parsing of various keys to the bot
@@ -210,7 +210,7 @@ class PlayerStats(commands.Cog):
         if not player_id:
             return await ctx.send(f"Could not find player: {player_name}. Please check your spelling and try again.")
 
-        if len(info_split) >= 3:
+        if len(info_split) > 2:
           for opt in info_split[2:]:
             #Checks if option is one of the output options
             try:


### PR DESCRIPTION
You can now set the limit, the ordering, whether you want it to output as a csv and what team you want to limit your search to. The order of the options does not matter.
 
- Limit has to be a positive integer. A value of less than zero will result in no limit. Default is 10
- Team is as formated in the `bot.team_names`. Default is no team
- Output format is either csv or inline. Default is inline.
- Sort Direction is whether you want the bottom or the top of the data stack.